### PR TITLE
Fix demo data, wrong model name

### DIFF
--- a/stock_move_location_dest_constraint_tag/demo/product_putaway.xml
+++ b/stock_move_location_dest_constraint_tag/demo/product_putaway.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="putaway_strat_acid_category" model="stock.fixed.putaway.strat">
+    <record id="putaway_strat_acid_category" model="stock.putaway.rule">
         <field name="category_id" ref="product_category_acid" />
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="location_out_id" ref="location_bin_acids" />
     </record>
-    <record id="putaway_strat_dangerous_category" model="stock.fixed.putaway.strat">
+    <record id="putaway_strat_dangerous_category" model="stock.putaway.rule">
         <field name="category_id" ref="product_category_dangerous" />
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="location_out_id" ref="location_bin_dangerous" />
     </record>
-    <record id="putaway_strat_ice_cream_product" model="stock.fixed.putaway.strat">
+    <record id="putaway_strat_ice_cream_product" model="stock.putaway.rule">
         <field name="product_id" ref="product_product_ice_cream" />
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="location_out_id" ref="stock.location_refrigerator_small" />
     </record>
-    <record id="putaway_strat_ammonium_product" model="stock.fixed.putaway.strat">
+    <record id="putaway_strat_ammonium_product" model="stock.putaway.rule">
         <field name="product_id" ref="product_product_ammonium_nitrate" />
         <field name="location_in_id" ref="stock.stock_location_stock" />
         <field name="location_out_id" ref="location_freezer_dangerous" />


### PR DESCRIPTION
@grindtildeath Demo data did not install due to:

```
2019-09-13 07:50:05,983 8841 INFO foo odoo.modules.loading: loading stock_move_location_dest_constraint_tag/demo/product_putaway.xml
2019-09-13 07:50:05,988 8841 WARNING foo odoo.models: stock.fixed.putaway.strat.create() with unknown fields: location_in_id, location_out_id
2019-09-13 07:50:05,988 8841 ERROR foo odoo.sql_db: bad query: b'INSERT INTO "stock_fixed_putaway_strat" ("id", "create_uid", "create_date", "write_uid", "write_date", "category_id") VALUES (nextval(\'stock_fixed_putaway_strat_id_seq\'), 1, (now() at time zone \'UTC\'), 1,
 (now() at time zone \'UTC\'), 10) RETURNING id'
ERROR: null value in column "putaway_id" violates not-null constraint
DETAIL:  Failing row contains (1, null, null, 10, null, null, 1, 2019-09-13 07:50:05.143194, 1, 2019-09-13 07:50:05.143194).

2019-09-13 07:50:05,989 8841 WARNING foo odoo.modules.loading: Module stock_move_location_dest_constraint_tag demo data failed to install, installed without demo data
Traceback (most recent call last):
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/tools/convert.py", line 758, in parse
    self._tags[rec.tag](rec, de, mode=mode)
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/tools/convert.py", line 663, in _tag_record
    record = model.with_context(rec_context)._load_records([data], self.mode == 'update')
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/models.py", line 3865, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/models.py", line 3779, in _load_records_create
    return self.create(values)
  File "<decorator-gen-3>", line 2, in create
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/api.py", line 452, in _model_create_multi
    return create(self, arg)
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/models.py", line 3560, in create
    records = self._create(data_list)
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/models.py", line 3660, in _create
    cr.execute(query, params)
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/sql_db.py", line 148, in wrapper
    return f(self, *args, **kwargs)
  File "/home/gbaconnier/nobackup/dev/v12/odoo/odoo/sql_db.py", line 225, in execute
    res = self._obj.execute(query, params)
psycopg2.IntegrityError: null value in column "putaway_id" violates not-null constraint
DETAIL:  Failing row contains (1, null, null, 10, null, null, 1, 2019-09-13 07:50:05.143194, 1, 2019-09-13 07:50:05.143194).
```

The field names seem to match with `stock.putaway.rule` so I changed to this model.