### PR TITLE
Remove unique constraint on location's name

### DIFF
--- a/stock_location_zone/models/stock_location.py
+++ b/stock_location_zone/models/stock_location.py
@@ -40,14 +40,6 @@ class StockLocation(models.Model):
              '* Other: any other location',
     )
 
-    _sql_constraints = [(
-        'name_zone_unique',
-        'EXCLUDE (name WITH =, zone_location_id WITH =)'
-        ' WHERE (zone_location_id IS NOT NULL)',
-        'Another location with the same name exists in the same zone.'
-        ' Please rename the location.'
-    )]
-
     @api.depends('is_zone', 'usage', 'location_id.usage', 'zone_location_id',
                  'child_ids')
     def _compute_location_kind(self):


### PR DESCRIPTION
It prevents other addons to work properly such as the vertical lift.
We remove the constraint for now, maybe to be re-introduced later in a
more permissive way.