### PR TITLE
Do not store area field

### DIFF
--- a/stock_location_bin_name/models/stock_location.py
+++ b/stock_location_bin_name/models/stock_location.py
@@ -19,7 +19,6 @@ class StockLocation(models.Model):
     area = fields.Char(
         'Area',
         compute='_compute_area',
-        store=True,
     )
 
     @api.depends('name', 'location_kind', 'location_id.area')


### PR DESCRIPTION
We only need it for the generation -> useless to
store it. It slows creation of locations for no value.
If we need to search on it, we can use a search method.